### PR TITLE
Added support for PHP version 5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ build-base:
 
 .PHONY: build-apache
 build-apache:
+	docker build -f php-apache/Dockerfile --build-arg php_version=5.6 -t ajitemsahasrabuddhe/php-apache:5.6-dev .
+	docker build -f php-apache/Dockerfile --build-arg php_version=5.6 --build-arg env=prod -t ajitemsahasrabuddhe/php-apache:5.6 .
 	docker build -f php-apache/Dockerfile --build-arg php_version=7.0 -t ajitemsahasrabuddhe/php-apache:7.0-dev .
 	docker build -f php-apache/Dockerfile --build-arg php_version=7.0 --build-arg env=prod -t ajitemsahasrabuddhe/php-apache:7.0 .
 	docker build -f php-apache/Dockerfile --build-arg php_version=7.1 -t ajitemsahasrabuddhe/php-apache:7.1-dev .
@@ -18,6 +20,8 @@ build-apache:
 
 .PHONY: build-nginx
 build-nginx:
+	docker build -f php-nginx/Dockerfile --build-arg php_version=5.6 -t ajitemsahasrabuddhe/php-nginx:5.6-dev .
+	docker build -f php-nginx/Dockerfile --build-arg php_version=5.6 --build-arg env=prod -t ajitemsahasrabuddhe/php-nginx:5.6 .
 	docker build -f php-nginx/Dockerfile --build-arg php_version=7.0 -t ajitemsahasrabuddhe/php-nginx:7.0-dev .
 	docker build -f php-nginx/Dockerfile --build-arg php_version=7.0 --build-arg env=prod -t ajitemsahasrabuddhe/php-nginx:7.0 .
 	docker build -f php-nginx/Dockerfile --build-arg php_version=7.1 -t ajitemsahasrabuddhe/php-nginx:7.1-dev .
@@ -30,6 +34,8 @@ build-nginx:
 .PHONY: push
 push:
 	docker push ajitemsahasrabuddhe/debian-base:1.1
+	docker push ajitemsahasrabuddhe/php-apache:5.6
+	docker push ajitemsahasrabuddhe/php-apache:5.6-dev
 	docker push ajitemsahasrabuddhe/php-apache:7.0
 	docker push ajitemsahasrabuddhe/php-apache:7.0-dev
 	docker push ajitemsahasrabuddhe/php-apache:7.1
@@ -38,6 +44,8 @@ push:
 	docker push ajitemsahasrabuddhe/php-apache:7.2-dev
 	docker push ajitemsahasrabuddhe/php-apache:7.3
 	docker push ajitemsahasrabuddhe/php-apache:7.3-dev
+	docker push ajitemsahasrabuddhe/php-nginx:5.6
+	docker push ajitemsahasrabuddhe/php-nginx:5.6-dev
 	docker push ajitemsahasrabuddhe/php-nginx:7.0
 	docker push ajitemsahasrabuddhe/php-nginx:7.0-dev
 	docker push ajitemsahasrabuddhe/php-nginx:7.1


### PR DESCRIPTION
PHP v7.x is the latest one that should be used, but many teams still use v5.6. Thereby adding support for the same.